### PR TITLE
Feature/trezo unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Notas das versões
+## [1.2.0 - 19/08/2019](https://github.com/vindi/vindi-magento2/releases/tag/1.2.0)
+- Corrige falha ao salvar as configurações de métodos de pagamento sem informar a chave API
+- Adiciona atribuicão de status padrao após confirmação de pagamento dos pedidos
+- Ajusta envio de descontos, fretes e taxas para a plataforma Vindi
+- Ajusta fluxo de compra em transações com suspeita de fraude
+
 ## [1.1.0 - 15/05/2019](https://github.com/vindi/vindi-magento2/releases/tag/1.1.0)
 - Insere método de pagamento Boleto Bancário
 

--- a/Model/Payment/AbstractMethod.php
+++ b/Model/Payment/AbstractMethod.php
@@ -203,7 +203,7 @@ abstract class AbstractMethod extends \Magento\Payment\Model\Method\AbstractMeth
                 || $body['payment_method_code'] === PaymentMethod::DEBIT_CARD
                 || $bill['status'] === Bill::PAID_STATUS
                 || $bill['status'] === Bill::REVIEW_STATUS
-                || $bill['charges'][0]['status'] === Bill::FRAUD_REVIEW_STATUS
+                || reset($bill['charges'])['status'] === Bill::FRAUD_REVIEW_STATUS
             ) {
                 $order->setVindiBillId($bill['id']);
                 return $bill['id'];

--- a/Model/Payment/Bill.php
+++ b/Model/Payment/Bill.php
@@ -7,7 +7,7 @@ class Bill
     private $api;
     const PAID_STATUS = 'paid';
     const REVIEW_STATUS = 'review';
-    const FRAUD_REVIEW_STATUS = 'review';
+    const FRAUD_REVIEW_STATUS = 'fraud_review';
 
     public function __construct(Api $api)
     {

--- a/Plugin/SetOrderStatusOnPlace.php
+++ b/Plugin/SetOrderStatusOnPlace.php
@@ -24,17 +24,17 @@ class SetOrderStatusOnPlace
         $this->helperData = $helperData;
     }
 
+    /** 
+     * Faz com que os status de pagamento dos pedidos
+     * sejam atualizados exclusivamente via webhooks da Vindi
+     * 
+     * @param Payment $subject, mixed $result
+     *
+     * @return mixed
+     */
     public function afterPlace(Payment $subject, $result)
     {
-        switch ($subject->getMethod()) {
-            case BankSlip::CODE:
-                $this->pendingStatus($subject);
-                break;
-            case Vindi::CODE:
-                $this->completeStatus($subject);
-                break;
-        }
-
+        $this->pendingStatus($subject);
         return $result;
     }
 

--- a/Test/Unit/StatusTest.php
+++ b/Test/Unit/StatusTest.php
@@ -37,7 +37,7 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('Expected Result', $result);
         $this->assertEquals($this->paymentMock->getOrder()->getState(), 'new');
-        $this->assertEquals(Order::STATE_PROCESSING, $this->paymentMock->getOrder()->getStatus());
+        $this->assertEquals('pending', $this->paymentMock->getOrder()->getStatus());
     }
 
     public function testSetPendingOrderStatusOnPlaceCreditCard()
@@ -67,20 +67,6 @@ class StatusTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->paymentMock->getOrder()->getState(), 'new');
         $this->assertEquals('pending', $this->paymentMock->getOrder()->getStatus());
     }
-
-    public function testSetPendingOrderStatusOnPlaceSlip2()
-    {
-        $this->paymentMock->method('getMethod')
-            ->willReturn(
-                \Vindi\Payment\Model\Payment\BankSlip::CODE
-            );
-
-        $result = $this->createPluginObjectManager('other')->afterPlace($this->paymentMock, 'Expected Result');
-
-        $this->assertEquals('Expected Result', $result);
-        $this->assertEquals($this->paymentMock->getOrder()->getState(), 'new');
-        $this->assertEquals('pending', $this->paymentMock->getOrder()->getStatus());
-    }    
 
     private function createHelperObjectManager($context)
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "vindi/vindi-magento2",
     "description": "Módulo de cobrança Vindi para o Magento 2",
     "type": "magento2-module",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": "GPL-3.0",
     "authors": [
         {

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,7 +8,7 @@
                 <allow_installments>0</allow_installments>
                 <title>Vindi</title>
                 <allowspecific>0</allowspecific>
-                <payment_action>authorize_capture</payment_action>
+                <payment_action>authorize</payment_action>
                 <group>offline</group>
             </vindi>
             <vindi_bankslip>


### PR DESCRIPTION
## Motivação

Alterações feitas pela Trezo no módulo de pagamento.

## Solução Proposta

Testes unitários para os métodos alterados e/ou criados pela Trezo para envio de informações adicionais no fechamento de pedidos, como descontos e taxas.

Para executar os testes, bastar rodar o seguinte comando na raiz do Magento onde o projeto está situado:

./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Vindi/Payment
